### PR TITLE
lock nvim-treesitter to stable version

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -73,6 +73,7 @@ local default_plugins = {
 
   {
     "nvim-treesitter/nvim-treesitter",
+    tag = "v0.9.2",
     init = function()
       require("core.utils").lazy_load "nvim-treesitter"
     end,


### PR DESCRIPTION
there has been a breaking change with nvimtreesitter https://github.com/nvim-treesitter/nvim-treesitter/pull/5895 which needs renaming many of the hlgroups,its already done in the v3.0 branch of base46, cant directly merge to v2.0 so for a while you all will have to use the 0.9.2 version